### PR TITLE
Add access-control-expose-headers to Nginx default config

### DIFF
--- a/installation/pleroma.nginx
+++ b/installation/pleroma.nginx
@@ -54,6 +54,7 @@ server {
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS' always;
         add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
+        add_header 'Access-Control-Expose-Headers' 'Link, X-RateLimit-Reset, X-RateLimit-Limit, X-RateLimit-Remaining, X-Request-Id' always;
         if ($request_method = OPTIONS) {
             return 204;
         }


### PR DESCRIPTION
Alternative webclients on different domains need access to some response headers for functionalities like endless scroll.
This should work using this additional header.