### PR TITLE
Repair some access-control headers required for third-party webclients

### DIFF
--- a/installation/pleroma.nginx
+++ b/installation/pleroma.nginx
@@ -52,8 +52,8 @@ server {
         # if you do not want remote frontends to be able to access your Pleroma backend
         # server, remove these lines.
         add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
+        add_header 'Access-Control-Allow-Methods' 'POST, PUT, DELETE, GET, PATCH, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Idempotency-Key' always;
         add_header 'Access-Control-Expose-Headers' 'Link, X-RateLimit-Reset, X-RateLimit-Limit, X-RateLimit-Remaining, X-Request-Id' always;
         if ($request_method = OPTIONS) {
             return 204;


### PR DESCRIPTION
Some access-control headers which are required for third-party webclients to work weren't complete.
Writing posts with idempotency-key and deleting posts works with these changes.